### PR TITLE
Support ayatana type

### DIFF
--- a/libqmenumodel/src/unitymenumodel.cpp
+++ b/libqmenumodel/src/unitymenumodel.cpp
@@ -455,7 +455,13 @@ QVariant UnityMenuModel::data(const QModelIndex &index, int role) const
 
         case TypeRole: {
             gchar *type;
-            if (gtk_menu_tracker_item_get_attribute (item, "x-canonical-type", "s", &type)) {
+            auto ret = gtk_menu_tracker_item_get_attribute (item, "x-ayatana-type", "s", &type);
+
+            // If we can't get x-ayatana-type, try legacy x-canonical-type type
+            if (!ret)
+                ret = gtk_menu_tracker_item_get_attribute (item, "x-canonical-type", "s", &type);
+
+            if (ret) {
                 QVariant v(type);
                 g_free (type);
                 return v;


### PR DESCRIPTION
This adds support for x-ayatana-type but keeps the old x-canonical-type
in case we have mixed type (as the case with ubuntu touch where we have
indicators that are yet to be moved to ayatana)