### PR TITLE
Move over qmenumodel into Ayatana Indicators project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 project(qmenumodel)
 
+set (PROJECT_VERSION "0.7.90")
+
 cmake_minimum_required(VERSION 2.8.9)
 
 # Standard install paths

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+qmenumodel (0.7.90-0) UNRELEASED; urgency=medium
+
+  * Move qmenumodel from UBports' project context over to
+    Ayatana Indicators' project context. Same maintainers,
+    same people involved, but the project is now maintained
+    together with the other Indicators' related projects.
+  * Upstream version bump (to go along with the other
+    indicator related projects maintained by the Ayatana
+    Indicators project). Next official release will be 0.8.0.
+
+ -- Mike Gabriel <mike.gabriel@das-netzwerkteam.de>  Sat, 15 Aug 2020 12:05:52 +0200
+
 qmenumodel (0.2.13+ubports1) xenial; urgency=medium
 
   [ Albert Astals Cid ]

--- a/debian/control
+++ b/debian/control
@@ -2,6 +2,8 @@ Source: qmenumodel
 Section: libs
 Priority: optional
 Maintainer: Marius Gripsgard <marius@ubports.com>
+Uploaders:
+ Mike Gabriel <mike.gabriel@das-netzwerkteam.de>
 Build-Depends: debhelper (>= 9.0.0),
                cmake (>= 2.8.9),
                cmake-extras,


### PR DESCRIPTION
This includes:

  - version bump to 0.7.90 (aligning with other upcoming AI releases, targetting 0.8.0)
  - shipping PROJECT_VERSION in CMakeLists.txt
  - adding myself as uploader in d/control (to silence dch tool)