### PR TITLE
Move glib includes outside of extern "C"

### DIFF
--- a/libqmenumodel/src/converter.cpp
+++ b/libqmenumodel/src/converter.cpp
@@ -18,9 +18,7 @@
  *      Marco Trevisan <marco.trevisan@canonical.com>
  */
 
-extern "C" {
 #include <glib.h>
-}
 
 #include "converter.h"
 

--- a/libqmenumodel/src/menunode.h
+++ b/libqmenumodel/src/menunode.h
@@ -25,9 +25,7 @@
 #include <QMap>
 #include <QVariant>
 
-extern "C" {
 #include <gio/gio.h>
-}
 
 class MenuNode
 {

--- a/libqmenumodel/src/qdbusactiongroup.cpp
+++ b/libqmenumodel/src/qdbusactiongroup.cpp
@@ -26,10 +26,8 @@
 // Qt
 #include <QCoreApplication>
 
-extern "C" {
 #include <glib.h>
 #include <gio/gio.h>
-}
 
 /*!
     \qmltype QDBusActionGroup

--- a/libqmenumodel/src/qdbusmenumodel.cpp
+++ b/libqmenumodel/src/qdbusmenumodel.cpp
@@ -17,9 +17,7 @@
  *      Renato Araujo Oliveira Filho <renato@canonical.com>
  */
 
-extern "C" {
 #include <gio/gio.h>
-}
 
 #include "qdbusmenumodel.h"
 #include "qmenumodelevents.h"

--- a/libqmenumodel/src/qdbusobject.cpp
+++ b/libqmenumodel/src/qdbusobject.cpp
@@ -17,10 +17,8 @@
  *      Renato Araujo Oliveira Filho <renato@canonical.com>
  */
 
-extern "C" {
 #include <glib-object.h>
 #include <gio/gio.h>
-}
 
 #include "qdbusobject.h"
 #include "qmenumodelevents.h"

--- a/libqmenumodel/src/qmenumodel.cpp
+++ b/libqmenumodel/src/qmenumodel.cpp
@@ -18,9 +18,7 @@
  *      Olivier Tilloy <olivier.tilloy@canonical.com>
  */
 
-extern "C" {
 #include <gio/gio.h>
-}
 
 #include "qmenumodel.h"
 #include "menunode.h"

--- a/libqmenumodel/src/qmenumodelevents.cpp
+++ b/libqmenumodel/src/qmenumodelevents.cpp
@@ -17,10 +17,8 @@
  *      Nicholas Dedekind <nick.dedekind@canonical.com
  */
 
-extern "C" {
 #include <glib-object.h>
 #include <gio/gio.h>
-}
 
 #include "qmenumodelevents.h"
 

--- a/libqmenumodel/src/unitymenumodelevents.cpp
+++ b/libqmenumodel/src/unitymenumodelevents.cpp
@@ -17,10 +17,8 @@
  *      Nicholas Dedekind <nick.dedekind@canonical.com
  */
 
-extern "C" {
 #include <glib-object.h>
 #include <gio/gio.h>
-}
 
 #include "unitymenumodelevents.h"
 #include "unitymenumodel.h"

--- a/tests/client/cachetest.cpp
+++ b/tests/client/cachetest.cpp
@@ -20,9 +20,7 @@
 
 #include "qmenumodel.h"
 
-extern "C" {
 #include <gio/gio.h>
-}
 
 #include <QtTest>
 

--- a/tests/client/convertertest.cpp
+++ b/tests/client/convertertest.cpp
@@ -18,9 +18,7 @@
  *      Marco Trevisan <marco.trevisan@canonical.com>
  */
 
-extern "C" {
 #include <glib.h>
-}
 
 #include "converter.h"
 

--- a/tests/client/modelsignalstest.cpp
+++ b/tests/client/modelsignalstest.cpp
@@ -23,9 +23,7 @@
 #include <QtTest>
 #include <QDebug>
 
-extern "C" {
 #include <gio/gio.h>
-}
 
 
 class MenuModelTestClass : public QMenuModel

--- a/tests/client/modeltest.cpp
+++ b/tests/client/modeltest.cpp
@@ -25,9 +25,7 @@
 #include <QtTest>
 #include <QDebug>
 
-extern "C" {
 #include <gio/gio.h>
-}
 
 class ModelTest : public QObject
 {

--- a/tests/client/qmltest.cpp
+++ b/tests/client/qmltest.cpp
@@ -17,9 +17,7 @@
  *      Renato Araujo Oliveira Filho <renato@canonical.com>
  */
 
-extern "C" {
 #include <glib-object.h>
-}
 
 #include "qdbusmenumodel.h"
 #include "dbusmenuscript.h"

--- a/tests/client/treetest.cpp
+++ b/tests/client/treetest.cpp
@@ -20,9 +20,7 @@
 
 #include "qmenumodel.h"
 
-extern "C" {
 #include <gio/gio.h>
-}
 
 #include <QtTest>
 


### PR DESCRIPTION
Recent glib versions throw this error otherwise:
```
In file included from /usr/include/glib-2.0/glib/gatomic.h:31,
                 from /usr/include/glib-2.0/glib/gthread.h:32,
                 from /usr/include/glib-2.0/glib/gasyncqueue.h:32,
                 from /usr/include/glib-2.0/glib.h:32,
                 from /home/pmos/build/src/qmenumodel-0.8.0/libqmenumodel/src/converter.cpp:22:
/usr/include/c++/10.2.1/type_traits:56:3: error: template with C linkage
   56 |   template<typename _Tp, _Tp __v>
      |   ^~~~~~~~
/home/pmos/build/src/qmenumodel-0.8.0/libqmenumodel/src/converter.cpp:21:1: note: 'extern "C"' linkage started here
   21 | extern "C" {
      | ^~~~~~~~~~
```