### PR TITLE
Workaround activatability of Ayatana switch menu item

### DIFF
--- a/libqmenumodel/src/gtk/gtkmenutrackeritem.c
+++ b/libqmenumodel/src/gtk/gtkmenutrackeritem.c
@@ -267,6 +267,24 @@ gtk_menu_tracker_item_action_added (GtkActionObserver   *observer,
                         (action_target != NULL && parameter_type != NULL &&
                         g_variant_is_of_type (action_target, parameter_type));
 
+  // Special-case org.ayatana.indicator.switch which is a target-less menu
+  // backed by an action with boolean parameter & state.
+  // FIXME: when the final fix is done, re-visit this.
+
+  GVariant *ayatana_type_v =
+    g_menu_item_get_attribute_value (self->item, "x-ayatana-type", G_VARIANT_TYPE_STRING);
+
+  if (ayatana_type_v != NULL) {
+    const gchar* ayatana_type = g_variant_get_string(ayatana_type_v, /* length out */ NULL);
+    if (g_str_equal(ayatana_type, "org.ayatana.indicator.switch")) {
+      self->can_activate |= (action_target == NULL && parameter_type != NULL &&
+                g_variant_type_equal (parameter_type, G_VARIANT_TYPE_BOOLEAN) &&
+                g_variant_is_of_type (state, G_VARIANT_TYPE_BOOLEAN));
+    }
+
+    g_variant_unref(ayatana_type_v);
+  }
+
   if (!self->can_activate)
     {
       if (action_target)


### PR DESCRIPTION
GtkMenuTrackerItem has the assumption that the GAction's parameter-type
and GMenuItem's "target" (i.e. "the parameter to pass when activating
the action" [1]) to match in type. This is reasonable, but Ayatana
Indicators' switch item doesn't follow it. Instead, it presents a
GMenuItem without a target, and a GAction with a boolean parameter.
ayatana-ido is then expected to pass the displaying switch's state as a
GAction's parameter.

Now, I'm not sure if breaking this assumption is the right thing to do,
but since the changes has shipped, we have to workaround it. This commit
makes a special case only for Ayatana Indicator's switch, so that it
won't break for anything else.

Workarounds https://github.com/AyatanaIndicators/qmenumodel/issues/21

[1] https://wiki.gnome.org/Projects/GLib/GApplication/DBusAPI#Attributes

-----------------------

Actually, I have another idea, based on how slider menu works. Thus, set this to a draft for now.