### PR TITLE
Port to Qt6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,11 +6,21 @@ if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 endif(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 
 # Options
+option(ENABLE_QT6 "Enable building with Qt6" OFF)
 option(ENABLE_TESTS "Enable all tests and checks" OFF)
 option(ENABLE_COVERAGE "Enable coverage reports (includes enabling all tests and checks)" OFF)
 option(ENABLE_WERROR "Treat all build warnings as errors" OFF)
 option(TEST_XML_OUTPUT "Print test results to xml files" OFF)
 option(GENERATE_DOC "Enable qdoc generation" OFF)
+
+set(QT_VERSION_MAJOR 5)
+set(QMENUMODEL_LIB_SUFFIX)
+set(QMENUMODEL_PKGCONFIG_SUFFIX)
+if(ENABLE_QT6)
+    set(QT_VERSION_MAJOR 6)
+    string(APPEND QMENUMODEL_LIB_SUFFIX "-qt6")
+    string(APPEND QMENUMODEL_PKGCONFIG_SUFFIX "-qt6")
+endif()
 
 if(ENABLE_COVERAGE)
     set(ENABLE_TESTS ON)
@@ -35,9 +45,8 @@ endif()
 
 # Standard install paths
 include(GNUInstallDirs)
-find_package(Qt5Core REQUIRED)
-find_package(Qt5Qml REQUIRED)
-find_package(Qt5Gui REQUIRED)
+find_package(QT NAMES Qt${QT_VERSION_MAJOR})
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Gui Qml Quick)
 include(FindPkgConfig)
 pkg_check_modules(GLIB REQUIRED glib-2.0>=2.32)
 pkg_check_modules(GIO REQUIRED gio-2.0>=2.32)
@@ -48,6 +57,7 @@ add_subdirectory(libqmenumodel)
 
 # Tests
 if (ENABLE_TESTS)
+    find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS DBus Test Widgets)
     find_program(DBUS_RUNNER dbus-test-runner REQUIRED)
     enable_testing()
     if(CMAKE_SYSTEM_PROCESSOR STREQUAL "armv7l")

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -7,13 +7,22 @@ cmake_minimum_required(VERSION 2.8.9)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 
-find_package(Qt5Core REQUIRED)
+option(ENABLE_QT6 "Enable building with Qt6" OFF)
+set(QT_VERSION_MAJOR 5)
+set(QMENUMODEL_PKGCONFIG_SUFFIX)
+if(ENABLE_QT6)
+    set(QT_VERSION_MAJOR 6)
+    string(APPEND QMENUMODEL_PKGCONFIG_SUFFIX "-qt6")
+endif()
+
+find_package(QT NAMES Qt${QT_VERSION_MAJOR})
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core)
 
 include(FindPkgConfig)
-pkg_check_modules(QMENUMODEL REQUIRED qmenumodel)
+pkg_check_modules(QMENUMODEL REQUIRED qmenumodel${QMENUMODEL_PKGCONFIG_SUFFIX})
 
 add_executable(info-menumodel info-menumodel.cpp)
 
 include_directories(${QMENUMODEL_INCLUDE_DIRS})
-target_link_libraries(info-menumodel ${QMENUMODEL_LDFLAGS} Qt5::Core)
+target_link_libraries(info-menumodel ${QMENUMODEL_LDFLAGS} Qt::Core)
 

--- a/libqmenumodel/QMenuModel/CMakeLists.txt
+++ b/libqmenumodel/QMenuModel/CMakeLists.txt
@@ -13,19 +13,17 @@ include_directories(
     ${GLIB_INCLUDE_DIRS}
 )
 
-find_package(Qt5Qml REQUIRED)
-find_package(Qt5Quick REQUIRED)
 target_link_libraries(qmenumodel-qml
-    qmenumodel
+    qmenumodel${QMENUMODEL_LIB_SUFFIX}
     ${GLIB_LDFLAGS}
     ${GIO_LDFLAGS}
-    Qt5::Qml Qt5::Quick
+    Qt::Qml Qt::Quick
 )
 
 execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/qmldir"
                                                               "${CMAKE_CURRENT_BINARY_DIR}/qmldir")
 
-set(QT_IMPORTS_DIR "${CMAKE_INSTALL_LIBDIR}/qt5/qml")
+set(QT_IMPORTS_DIR "${CMAKE_INSTALL_LIBDIR}/qt${QT_VERSION_MAJOR}/qml")
 set(QMLPLUGIN_INSTALL_PREFIX "${QT_IMPORTS_DIR}/QMenuModel.1")
 install(TARGETS qmenumodel-qml DESTINATION ${QMLPLUGIN_INSTALL_PREFIX})
 install(FILES qmldir DESTINATION ${QMLPLUGIN_INSTALL_PREFIX})

--- a/libqmenumodel/src/CMakeLists.txt
+++ b/libqmenumodel/src/CMakeLists.txt
@@ -29,7 +29,7 @@ set(QMENUMODEL_SRC
     gtk/gtkmenutrackeritem.h
 )
 
-set(SHAREDLIBNAME qmenumodel)
+set(SHAREDLIBNAME qmenumodel${QMENUMODEL_LIB_SUFFIX})
 add_library(${SHAREDLIBNAME} SHARED
     ${QMENUMODEL_SRC}
 )
@@ -45,11 +45,10 @@ include_directories(
     ${GIO_INCLUDE_DIRS}
 )
 
-find_package(Qt5Quick REQUIRED)
 target_link_libraries(${SHAREDLIBNAME}
     ${GLIB_LDFLAGS}
     ${GIO_LDFLAGS}
-    Qt5::Core Qt5::Qml Qt5::Quick
+    Qt::Core Qt::Qml Qt::Quick
 )
 
 install(TARGETS ${SHAREDLIBNAME} LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
@@ -71,8 +70,8 @@ install(FILES ${QMENUMODEL_HEADERS}
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${INCLUDEDIR}
 )
 
-set(PCFILE qmenumodel.pc)
-configure_file(${PCFILE}.in ${CMAKE_CURRENT_BINARY_DIR}/${PCFILE} @ONLY)
+set(PCFILE qmenumodel${QMENUMODEL_PKGCONFIG_SUFFIX}.pc)
+configure_file(qmenumodel.pc.in ${CMAKE_CURRENT_BINARY_DIR}/${PCFILE} @ONLY)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PCFILE}
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
 )

--- a/libqmenumodel/src/ayatanamenuaction.h
+++ b/libqmenumodel/src/ayatanamenuaction.h
@@ -21,7 +21,10 @@
 
 #include <QObject>
 #include <QVariant>
+
+// cyclical includes, forward-declare
 class AyatanaMenuModel;
+#include "ayatanamenumodel.h"
 
 class AyatanaMenuAction: public QObject
 {

--- a/libqmenumodel/src/ayatanamenumodel.cpp
+++ b/libqmenumodel/src/ayatanamenumodel.cpp
@@ -463,7 +463,7 @@ QVariant AyatanaMenuModel::data(const QModelIndex &index, int role) const
                 ret = gtk_menu_tracker_item_get_attribute (item, "x-canonical-type", "s", &type);
 
             if (ret) {
-                QVariant v(type);
+                QString v(type);
                 g_free (type);
                 return v;
             }
@@ -658,7 +658,7 @@ static QString qtify_name(const char *name)
         if (*name == '-') {
             next_cap = true;
         } else if (next_cap) {
-            result.append(toupper(*name));
+            result.append(QChar (toupper(*name)));
             next_cap = false;
         } else {
             result.append(*name);

--- a/libqmenumodel/src/ayatanamenumodel.h
+++ b/libqmenumodel/src/ayatanamenumodel.h
@@ -20,9 +20,13 @@
 #define AYATANAMENUMODEL_H
 
 #include <QAbstractListModel>
-class ActionStateParser;
-class QQmlComponent;
+#include <QQmlComponent>
+
+#include "actionstateparser.h"
+
+// cyclical includes, forward-declare
 class AyatanaMenuAction;
+#include "ayatanamenuaction.h"
 
 class AyatanaMenuModel: public QAbstractListModel
 {

--- a/libqmenumodel/src/converter.cpp
+++ b/libqmenumodel/src/converter.cpp
@@ -166,7 +166,13 @@ GVariant* Converter::toGVariant(const QVariant &value)
     if (value.isNull() || !value.isValid())
         return result;
 
-    switch((QMetaType::Type)value.type()) {
+    switch(
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+        value.typeId()
+#else
+        (QMetaType::Type)value.type()
+#endif
+    ) {
     case QMetaType::Bool:
         result = g_variant_new_boolean(value.toBool());
         break;
@@ -255,7 +261,13 @@ GVariant* Converter::toGVariant(const QVariant &value)
         break;
     }
     default:
-        qWarning() << "QVariant type not supported:" << value.type();
+        qWarning() << "QVariant type not supported:" <<
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+            value.metaType()
+#else
+            value.type()
+#endif
+            ;
     }
 
     return result;
@@ -313,11 +325,23 @@ GVariant* Converter::toGVariantWithSchema(const QVariant &value, const char* sch
     } else if (g_variant_type_equal(schema_type, G_VARIANT_TYPE_VARIANT)) {
         result = g_variant_new_variant(Converter::toGVariant(value));
     } else if (g_variant_type_equal(schema_type, G_VARIANT_TYPE_VARDICT)) {
-        if (value.canConvert(QVariant::Map)) {
+        if (value.canConvert(
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+            QMetaType (QVariant::Map)
+#else
+            QVariant::Map
+#endif
+        )) {
             result = Converter::toGVariant(value.toMap());
         }
     } else if (g_variant_type_is_array(schema_type)) {
-        if (value.canConvert(QVariant::List)) {
+        if (value.canConvert(
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+            QMetaType (QVariant::List)
+#else
+            QVariant::List
+#endif
+        )) {
             const GVariantType* entryType = g_variant_type_element(schema_type);
             const gchar* entryTypeString = g_variant_type_peek_string(entryType);
 
@@ -341,7 +365,13 @@ GVariant* Converter::toGVariantWithSchema(const QVariant &value, const char* sch
             g_variant_builder_unref(b);
         }
     } else if (g_variant_type_is_tuple(schema_type)) {
-        if (value.canConvert(QVariant::List)) {
+        if (value.canConvert(
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+            QMetaType (QVariant::List)
+#else
+            QVariant::List
+#endif
+        )) {
             const GVariantType* entryType = g_variant_type_first(schema_type);
 
             GVariantBuilder *b = g_variant_builder_new(G_VARIANT_TYPE_TUPLE);

--- a/libqmenumodel/src/converter.h
+++ b/libqmenumodel/src/converter.h
@@ -20,9 +20,10 @@
 #ifndef CONVERTER_H
 #define CONVERTER_H
 
+#include <QString>
+#include <QVariant>
+
 typedef struct _GVariant GVariant;
-class QString;
-class QVariant;
 
 class Converter
 {

--- a/libqmenumodel/src/qdbusactiongroup.h
+++ b/libqmenumodel/src/qdbusactiongroup.h
@@ -25,8 +25,11 @@
 #include <QObject>
 #include <QVariant>
 
+#include "actionstateparser.h"
+
+// cyclical includes, forward-declare
 class QStateAction;
-class ActionStateParser;
+#include "qstateaction.h"
 
 typedef char gchar;
 typedef void* gpointer;

--- a/libqmenumodel/src/qmenumodel.h
+++ b/libqmenumodel/src/qmenumodel.h
@@ -22,7 +22,8 @@
 
 #include <QAbstractItemModel>
 
-class MenuNode;
+#include "menunode.h"
+
 typedef struct _GMenuModel GMenuModel;
 
 class QMenuModel : public QAbstractItemModel

--- a/libqmenumodel/src/qmenumodel.pc.in
+++ b/libqmenumodel/src/qmenumodel.pc.in
@@ -7,7 +7,7 @@ Name: qmenumodel
 Description: Qt binding for GMenuModel.
 Version: @CMAKE_PROJECT_VERSION@
 
-Requires.private: Qt5Core Qt5Widgets gio-2.0
+Requires.private: Qt@QT_VERSION_MAJOR@Core Qt@QT_VERSION_MAJOR@Widgets gio-2.0
 Libs: -L${libdir} -l@SHAREDLIBNAME@
 Cflags: -I${includedir}/@INCLUDEDIR@
 

--- a/libqmenumodel/src/qmenumodelevents.h
+++ b/libqmenumodel/src/qmenumodelevents.h
@@ -23,7 +23,8 @@
 #include <QEvent>
 #include <QVariant>
 
-class MenuNode;
+#include "menunode.h"
+
 typedef struct _GDBusConnection GDBusConnection;
 typedef struct _GMenuModel GMenuModel;
 

--- a/libqmenumodel/src/qstateaction.cpp
+++ b/libqmenumodel/src/qstateaction.cpp
@@ -95,7 +95,13 @@ bool QStateAction::isValid() const
 void QStateAction::updateState(const QVariant &state)
 {
     QVariant v = state;
-    if (v.convert(m_state.type()))
+    if (v.convert(
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+      m_state.metaType()
+#else
+      m_state.type()
+#endif
+    ))
       m_group->updateActionState(m_name, v);
 }
 
@@ -146,7 +152,13 @@ void QStateAction::setValid(bool valid)
 void QStateAction::setState(const QVariant &state)
 {
     QVariant v = state;
-    if (!m_state.isValid() || (v.convert(m_state.type()) && v != m_state)) {
+    if (!m_state.isValid() || (v.convert(
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+        m_state.metaType()
+#else
+        m_state.type()
+#endif
+      ) && v != m_state)) {
         m_state = v;
         Q_EMIT stateChanged(m_state);
     }

--- a/libqmenumodel/src/qstateaction.h
+++ b/libqmenumodel/src/qstateaction.h
@@ -23,7 +23,9 @@
 #include <QObject>
 #include <QVariant>
 
+// cyclical includes, forward-declare
 class QDBusActionGroup;
+#include "qdbusactiongroup.h"
 
 class QStateAction : public QObject
 {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,2 @@
-find_package(Qt5Quick REQUIRED)
-find_package(Qt5Test REQUIRED)
-find_package(Qt5Widgets REQUIRED)
-find_package(Qt5DBus REQUIRED)
-
 add_subdirectory(script)
 add_subdirectory(client)

--- a/tests/client/CMakeLists.txt
+++ b/tests/client/CMakeLists.txt
@@ -1,16 +1,16 @@
 macro(declare_test testname)
     add_executable(${testname} ${testname}.cpp)
     target_link_libraries(${testname}
-                          qmenumodel
+                          qmenumodel${QMENUMODEL_LIB_SUFFIX}
                           dbusmenuscript
                           ${GLIB_LDFLAGS}
                           ${GIO_LDFLAGS}
-                          Qt5::Core
-                          Qt5::DBus
-                          Qt5::Widgets
-                          Qt5::Test
-                          Qt5::Qml
-                          Qt5::Quick
+                          Qt::Core
+                          Qt::DBus
+                          Qt::Widgets
+                          Qt::Test
+                          Qt::Qml
+                          Qt::Quick
     )
 
     if(TEST_XML_OUTPUT)
@@ -34,11 +34,11 @@ endmacro(declare_test testname)
 macro(declare_simple_test testname)
     add_executable(${testname} ${testname}.cpp)
     target_link_libraries(${testname}
-                          qmenumodel
+                          qmenumodel${QMENUMODEL_LIB_SUFFIX}
                           ${GLIB_LDFLAGS}
                           ${GIO_LDFLAGS}
-                          Qt5::Core
-                          Qt5::Test
+                          Qt::Core
+                          Qt::Test
     )
 
     add_test(${testname}
@@ -76,7 +76,7 @@ if (ENABLE_COVERAGE)
     find_package(CoverageReport)
     ENABLE_COVERAGE_REPORT(
       TARGETS
-        qmenumodel
+        qmenumodel${QMENUMODEL_LIB_SUFFIX}
       FILTER
         ${CMAKE_SOURCE_DIR}/tests/*
         ${CMAKE_BINARY_DIR}/*

--- a/tests/client/convertertest.cpp
+++ b/tests/client/convertertest.cpp
@@ -72,14 +72,26 @@ private:
         g_variant_unref(gv);
         return result;
     }
-    bool compare(GVariant *gv, const QVariant::Type type)
+    bool compare(GVariant *gv, const QMetaType::Type type)
     {
         g_variant_ref_sink(gv);
         const QVariant& qv = Converter::toQVariant(gv);
-        bool result = (qv.type() == type);
+        bool result = (
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+            qv.typeId()
+#else
+            (QMetaType::Type)qv.type()
+#endif
+            == type
+        );
         if (!result) {
             qWarning() << "types are different: GVariant:" << g_variant_type_peek_string(g_variant_get_type(gv))
-                       << "Result:" << qv.type()
+                       << "Result:" <<
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+                           qv.typeId()
+#else
+                           qv.type()
+#endif
                        << "Expected:"<< type;
         }
         g_variant_unref(gv);
@@ -300,7 +312,7 @@ private Q_SLOTS:
         QFETCH(QGVariant, value);
         QFETCH(unsigned, expectedType);
 
-        QVERIFY(compare(value, (QVariant::Type) expectedType));
+        QVERIFY(compare(value, (QMetaType::Type) expectedType));
     }
 
     void testConvertToQVariantAndBack_data()
@@ -318,7 +330,14 @@ private Q_SLOTS:
         GVariant *gv = Converter::toGVariant(qv);
         gboolean equals = g_variant_equal(value, gv);
 
-        if (!equals && qv.type() == QVariant::List) {
+        if (!equals && (
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+            qv.typeId()
+#else
+            qv.type()
+#endif
+            == QVariant::List
+        )) {
             QVERIFY(g_variant_type_is_array(g_variant_get_type(value)));
             QVERIFY(g_variant_type_is_tuple(g_variant_get_type(gv)));
 
@@ -373,7 +392,15 @@ private Q_SLOTS:
         QFETCH(QString, value);
         QFETCH(unsigned, expectedType);
 
-        QCOMPARE(Converter::toQVariantFromVariantString(value).type(), (QVariant::Type) expectedType);
+        QCOMPARE(
+            Converter::toQVariantFromVariantString(value)
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+                .typeId()
+#else
+                .type()
+#endif
+            , (QMetaType::Type) expectedType
+        );
     }
 
 };

--- a/tests/client/modeltest.cpp
+++ b/tests/client/modeltest.cpp
@@ -106,13 +106,27 @@ private Q_SLOTS:
         // Label (String)
         QVariant label = m_model.data(m_model.index(0, 0), QMenuModel::Label);
         QVERIFY(label.isValid());
-        QCOMPARE(label.type(), QVariant::String);
+        QCOMPARE(
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+            label.typeId()
+#else
+            label.type()
+#endif
+            , QVariant::String
+        );
         QCOMPARE(label.toString(), QString("Menu0"));
 
         // Action (String)
         QVariant action = m_model.data(m_model.index(1, 0), QMenuModel::Action);
         QVERIFY(action.isValid());
-        QCOMPARE(action.type(), QVariant::String);
+        QCOMPARE(
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+            action.typeId()
+#else
+            action.type()
+#endif
+            , QVariant::String
+        );
         QCOMPARE(action.toString(), QString("Menu1Act"));
 
         // Wait for menu load (submenus are loaded async)
@@ -144,7 +158,14 @@ private Q_SLOTS:
 
         // Boolean
         QVariant v = extra["boolean"];
-        QCOMPARE(v.type(), QVariant::Bool);
+        QCOMPARE(
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+            v.typeId()
+#else
+            v.type()
+#endif
+            , QVariant::Bool
+        );
         QCOMPARE(v.toBool(), true);
 
         // Byte
@@ -164,32 +185,74 @@ private Q_SLOTS:
 
         // Int32
         v = extra["int32"];
-        QCOMPARE(v.type(), QVariant::Int);
+        QCOMPARE(
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+            v.typeId()
+#else
+            v.type()
+#endif
+            , QVariant::Int
+        );
         QCOMPARE(v.toInt(), -42);
 
         // UInt32
         v = extra["uint32"];
-        QCOMPARE(v.type(), QVariant::UInt);
+        QCOMPARE(
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+            v.typeId()
+#else
+            v.type()
+#endif
+            , QVariant::UInt
+        );
         QCOMPARE(v.toUInt(), (uint) 42);
 
         // Int64
         v = extra["int64"];
-        QCOMPARE(v.type(), QVariant::LongLong);
+        QCOMPARE(
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+            v.typeId()
+#else
+            v.type()
+#endif
+            , QVariant::LongLong
+        );
         QCOMPARE(v.value<long>(), (long) -42);
 
         // UInt64
         v = extra["uint64"];
-        QCOMPARE(v.type(), QVariant::ULongLong);
+        QCOMPARE(
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+            v.typeId()
+#else
+            v.type()
+#endif
+            , QVariant::ULongLong
+        );
         QCOMPARE(v.value<ulong>(), (ulong) 42);
 
         // Double
         v = extra["double"];
-        QCOMPARE(v.type(), QVariant::Double);
+        QCOMPARE(
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+            v.typeId()
+#else
+            v.type()
+#endif
+            , QVariant::Double
+        );
         QCOMPARE(v.toDouble(), 42.42);
 
         // String
         v = extra["string"];
-        QCOMPARE(v.type(), QVariant::String);
+        QCOMPARE(
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+            v.typeId()
+#else
+            v.type()
+#endif
+            , QVariant::String
+        );
         QCOMPARE(v.toString(), QString("42"));
 
         // Map
@@ -199,19 +262,40 @@ private Q_SLOTS:
         map.insert("string", "42");
         map.insert("double", 42.42);
 
-        QCOMPARE(v.type(), QVariant::Map);
+        QCOMPARE(
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+            v.typeId()
+#else
+            v.type()
+#endif
+            , QVariant::Map
+        );
         QCOMPARE(v.toMap(), map);
 
         // Utf8
         v = extra["utf8"];
-        QCOMPARE(v.type(), QVariant::String);
+        QCOMPARE(
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+            v.typeId()
+#else
+            v.type()
+#endif
+            , QVariant::String
+        );
         QCOMPARE(v.toString(), QString("dança"));
 
         // Tuple
         v = extra["tuple"];
         QVariantList lst;
         lst << "1" << 2 << 3.3;
-        QCOMPARE(v.type(), QVariant::List);
+        QCOMPARE(
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+            v.typeId()
+#else
+            v.type()
+#endif
+            , QVariant::List
+        );
         QCOMPARE(v.toList(), lst);
    }
 

--- a/tests/script/CMakeLists.txt
+++ b/tests/script/CMakeLists.txt
@@ -4,5 +4,5 @@ add_library(dbusmenuscript STATIC dbusmenuscript.cpp)
 
 set_target_properties(dbusmenuscript PROPERTIES COMPILE_FLAGS -fPIC)
 
-target_link_libraries(dbusmenuscript Qt5::Core Qt5::DBus Qt5::Test)
+target_link_libraries(dbusmenuscript Qt::Core Qt::DBus Qt::Test)
 


### PR DESCRIPTION
Closes #27

~~Still needs a little bit of work to allow side-by-side installation of Qt5 & Qt6 libraries on the same Linux FHS implementing distro.~~ Should be fine now I think, tested locally in Nixpkgs. Repo has no CI to test this however. :(

Qt6 build is not integration tested yet, as that needs Lomiri to be ported to Qt6. Qt5 build still worked in Lomiri (after reverting ceaa2df6e9f96245a0e99edeb29a8b28c39c79b1 for #28).