### PR TITLE
tests: Increase test timeout

### DIFF
--- a/tests/script/dbusmenuscript.cpp
+++ b/tests/script/dbusmenuscript.cpp
@@ -22,7 +22,7 @@
 #include <QtTestGui>
 #include <QDebug>
 
-#define WAIT_TIMEOUT   500
+#define WAIT_TIMEOUT   2000
 
 DBusMenuScript::DBusMenuScript()
     :m_script(0)


### PR DESCRIPTION
from .5 second to 2 seconds

Helps riscv64 for Debian

https://bugs.debian.org/1086635