### PR TITLE
tests/client/CMakeLists.txt: Fix inter-task dependencies

### DIFF
--- a/tests/client/CMakeLists.txt
+++ b/tests/client/CMakeLists.txt
@@ -21,9 +21,10 @@ macro(declare_test testname)
 
     add_test(${testname}
              ${DBUS_RUNNER}
-             --task ${CMAKE_CURRENT_BINARY_DIR}/${testname} ${TEST_ARGS} --task-name Client
              --task ${CMAKE_CURRENT_SOURCE_DIR}/script_${testname}.py --task-name Server
-             --ignore-return)
+             --ignore-return
+             --task ${CMAKE_CURRENT_BINARY_DIR}/${testname} ${TEST_ARGS} --task-name Client
+             --wait-for org.ayatana.test)
     set_tests_properties(${testname} PROPERTIES
                          TIMEOUT ${CTEST_TESTING_TIMEOUT}
                          ENVIRONMENT "PYTHONPATH=${TEST_PYTHONPATH};QT_QPA_PLATFORM=minimal")
@@ -45,7 +46,8 @@ macro(declare_simple_test testname)
              ${CMAKE_CURRENT_BINARY_DIR}/${testname})
 
     set_tests_properties(${testname} PROPERTIES
-                         TIMEOUT ${CTEST_TESTING_TIMEOUT})
+                         TIMEOUT ${CTEST_TESTING_TIMEOUT}
+                         ENVIRONMENT "QT_QPA_PLATFORM=minimal")
 endmacro(declare_simple_test testname)
 
 include_directories(${src_SOURCE_DIR}
@@ -64,10 +66,10 @@ declare_test(menuchangestest)
 declare_test(modeltest)
 declare_test(actiongrouptest)
 declare_test(qmltest)
-declare_test(convertertest)
-declare_test(modelsignalstest)
-declare_test(treetest)
-declare_test(ayatanamenuactiontest)
+declare_simple_test(convertertest)
+declare_simple_test(modelsignalstest)
+declare_simple_test(treetest)
+declare_simple_test(ayatanamenuactiontest)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/qmlfiles.h.in
                ${CMAKE_CURRENT_BINARY_DIR}/qmlfiles.h)


### PR DESCRIPTION
Some of the tests rely on `org.ayatana.test` existing in the test D-Bus session, which gets started by their accompanying Python scripts. Add a `--wait-for org.ayatana.test` to make sure that the test only starts once the service is present.

This causes some of the tests to fail because they don't have an accompanying Python script, so the interface never appears. Switch those tests to the previously unused `declare_simple_test` macro, and adjust it slightly so everything works out.

---

Caused random test failures on my slow 21 year old POWER machine, because this relied on the Server task exposing the required D-Bus interface on the test bus before the Client task was looking for it. Adding this dependency between the two seems like the correct way of handling this.